### PR TITLE
실제 대화목록 조회 및 config 기반 API 엔드포인트 적용

### DIFF
--- a/src/component/home/sidebar.jsx
+++ b/src/component/home/sidebar.jsx
@@ -2,6 +2,7 @@ import React, { useState, useContext, useEffect } from "react";
 import "./sidebar.css";
 import Rab from "../../asset/rabbit.png";
 import { AuthContext } from "../../AuthContext";
+import { config } from "../../config.js"
 
 const Sidebar = () => {
   const { isLoggedIn } = useContext(AuthContext);
@@ -29,13 +30,9 @@ const Sidebar = () => {
   useEffect(() => {
     if (!isLoggedIn) return;
 
-    // 로컬 스토리지에서 필요한 값 가져오기
     const token = localStorage.getItem("token");
-    const nickname = localStorage.getItem("nickname");
-    const user_model = localStorage.getItem("user_model");
 
-    // fetch로 POST 요청 - 헤더에 토큰, nickname, user_model 전부 담아서 전송
-    fetch("http://localhost:8080/chat/list", {
+    fetch(`${config.hosting.ip}:${config.hosting.back_port}/chat/list`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/src/component/login/Login.jsx
+++ b/src/component/login/Login.jsx
@@ -4,7 +4,7 @@ import loginStyles from "./Login.module.css";
 import logo from "../../asset/logo.png";
 import kakao from "../../asset/Kakao_logo.png";
 import { config } from "../../config.js";
-import { AuthContext } from "../../AuthContext.js"; // AuthContext import
+import { AuthContext } from "../../AuthContext.js";
 import { MdCancel } from "react-icons/md";
 
 const Login = ({ isModalOpen, closeLoginModal, openRegistModal, }) => {
@@ -37,7 +37,7 @@ const Login = ({ isModalOpen, closeLoginModal, openRegistModal, }) => {
   // 로그인 API 호출
   const fetchLogin = async () => {
     try {
-      const response = await fetch("http://localhost:8080/auth/login", {
+      const response = await fetch(`${config.hosting.ip}:${config.hosting.back_port}/auth/login`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ username, password }),

--- a/src/component/regist/Regist.jsx
+++ b/src/component/regist/Regist.jsx
@@ -3,6 +3,7 @@ import axios from "axios";
 import registStyles from "./Regist.module.css";
 import { MdCancel } from "react-icons/md";
 import { FaArrowLeft } from "react-icons/fa6";
+import { config } from "../../config.js"
 
 const Regist = ({ isModalOpen, closeRegistModal, openLoginModal }) => {
   // (아이디, 비밀번호, 비밀번호 확인, 이메일, 닉네임)
@@ -62,7 +63,8 @@ const Regist = ({ isModalOpen, closeRegistModal, openLoginModal }) => {
     // 아이디 중복 체크 요청 (서버 엔드포인트: /auth/username-dupl-chk)
     setIsCheckingUserid(true);
     try {
-      const response = await axios.post('http://localhost:8080/auth/username-dupl-chk', { username: currentUserid });
+      const response = await axios.post(`${config.hosting.ip}:${config.hosting.back_port}/auth/username-dupl-chk`
+, { username: currentUserid });
       console.log("중복체크 응답:", response.data);
       if (!response.data.status) {
         setUseridMessage("이미 사용 중인 아이디입니다.");
@@ -138,7 +140,7 @@ const Regist = ({ isModalOpen, closeRegistModal, openLoginModal }) => {
       return;
     }
     try {
-      const response = await axios.post('http://localhost:8080/auth/send-email', { username: username, receiver: email });
+      const response = await axios.post(`${config.hosting.ip}:${config.hosting.back_port}/auth/send-email`, { username: username, receiver: email });
       if (response.data.status) {
         setCodeMessage("인증번호가 전송되었습니다. 이메일을 확인해주세요.");
         setShowVerificationInput(true);
@@ -157,7 +159,7 @@ const Regist = ({ isModalOpen, closeRegistModal, openLoginModal }) => {
       return;
     }
     try {
-      const response = await axios.post('http://localhost:8080/auth/verify-email', { username: username, auth_number: emailverificationCode });
+      const response = await axios.post(`${config.hosting.ip}:${config.hosting.back_port}/auth/verify-email`, { username: username, auth_number: emailverificationCode });
       console.log("이메일 인증 응답:", response.data);
       if (response.data.status) {
         setCodeMessage("인증번호가 확인되었습니다.");
@@ -203,7 +205,7 @@ const Regist = ({ isModalOpen, closeRegistModal, openLoginModal }) => {
   const handleSubmitRegistration = async (e) => {
     e.preventDefault();
     try {
-      const response = await axios.post("http://localhost:8080/auth/create", {
+      const response = await axios.post(`${config.hosting.ip}:${config.hosting.back_port}/auth/create`, {
         username: username,
         password: password,
         email: email,

--- a/src/config.js
+++ b/src/config.js
@@ -7,6 +7,7 @@ function getEnvValueWithDefault(key, defaultValue = undefined) {
       front_port: getEnvValueWithDefault("REACT_APP_FRONT_PORT"),
       back_port: getEnvValueWithDefault("REACT_APP_BACK_PORT"),
       model_port: getEnvValueWithDefault("REACT_APP_MODEL_PORT"),
+      ip: getEnvValueWithDefault("REACT_APP_IP")
     },
     db: {
       url: getEnvValueWithDefault("REACT_APP_MONGO_URL"),

--- a/src/page/home/Chat.css
+++ b/src/page/home/Chat.css
@@ -163,7 +163,7 @@
   cursor: pointer;
 }
 .close-icon:hover {
-  color: red;
+  color: pink;
 }
 
 /************************************


### PR DESCRIPTION
- Sidebar 컴포넌트에서 하드코딩된 localhost 주소 대신 config 파일에 정의된 env 변수(config.hosting.ip, config.hosting.back_port)를 사용하여 API 엔드포인트를 구성함.
- 로그인 상태인 경우 백엔드의 /chat/list API를 호출하여 실제 대화목록을 가져오고, 비로그인 상태에서는 더미 데이터를 표시하도록 처리.
- 날짜 포맷팅 및 대화목록 섹션 구분 로직을 유지하며, UI 렌더링 방식도 개선함.
- 백엔드와 연동 테스트를 위한 기본적인 fetch 로직을 추가함.
